### PR TITLE
Added config for Second negatus instance on reboot.

### DIFF
--- a/mac/org.mozilla.Negatus.plist
+++ b/mac/org.mozilla.Negatus.plist
@@ -7,6 +7,7 @@
         <string>org.mozilla.Negatus</string>
 	<key>Program</key>
         <string>/Users/mozilla/src/Negatus/agent</string>
+        <string>/Users/mozilla/src/Negatus/agent -p 20703 --heartbeat 20702</string>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>


### PR DESCRIPTION
Added an extra string to start the second instance of Negatus on port
20703. This is to facilitate the —killall option from steeplechase
which relies on a second Negatus running on the Mac machine.
