### PR TITLE
Bug 1217584 - Submit results to Treeherder's API using Hawk credentials

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ blessings==1.6
 boto==2.38.0
 httplib2==0.9.1
 manifestparser==1.1
+mohawk==0.3.0
 mozdevice==0.46
 mozfile==1.2
 mozinfo==0.8
@@ -10,6 +11,7 @@ moznetwork==0.27
 mozprocess==0.22
 mozversion==1.3
 oauth2==1.5.211
-requests==2.7.0
-treeherder-client==1.6
+requests==2.8.1
+requests-hawk==0.2.1
+treeherder-client==1.8.0
 python-dateutil==2.2

--- a/treeherding.py
+++ b/treeherding.py
@@ -19,7 +19,7 @@ import json
 
 import mozinfo
 import mozversion
-from thclient import TreeherderAuth, TreeherderClient, TreeherderJobCollection
+from thclient import TreeherderClient, TreeherderJobCollection
 
 from s3 import S3Error
 
@@ -303,12 +303,10 @@ class TreeherderSubmission(object):
                           'job_collection =\n%s' %
                           pretty(job_collection.get_collection_data()))
 
-        auth = TreeherderAuth(self.credentials[project]['consumer_key'],
-                              self.credentials[project]['consumer_secret'],
-                              project)
         client = TreeherderClient(protocol=self.protocol,
                                   host=self.server,
-                                  auth=auth)
+                                  client_id=self.credentials['client_id'],
+                                  secret=self.credentials['secret'])
         for attempt in range(1, self.retries + 1):
             try:
                 client.post_collection(project, job_collection)

--- a/treeherding.py
+++ b/treeherding.py
@@ -434,7 +434,6 @@ class TreeherderSubmission(object):
             # XXX need to send these until Bug 1066346 fixed.
             tj.add_start_timestamp(j.submit_timestamp)
             tj.add_end_timestamp(j.submit_timestamp)
-            tj.add_build_url(j.build_url)
             tj.add_build_info(j.build['os_name'],
                               j.build['platform'],
                               j.build['architecture'])
@@ -499,7 +498,6 @@ class TreeherderSubmission(object):
             tj.add_end_timestamp(j.start_timestamp)
             #
             tj.add_machine(j.machine['host'])
-            tj.add_build_url(j.build_url)
             tj.add_build_info(j.build['os_name'],
                               j.build['platform'],
                               j.build['architecture'])
@@ -582,8 +580,6 @@ class TreeherderSubmission(object):
             tj.add_submit_timestamp(j.submit_timestamp)
             tj.add_start_timestamp(j.start_timestamp)
             tj.add_end_timestamp(j.end_timestamp)
-            if j.build_url:
-                tj.add_build_url(j.build_url)
             tj.add_build_info(j.build['os_name'],
                               j.build['platform'],
                               j.build['architecture'])
@@ -733,7 +729,6 @@ class TestJob(object):
         # May include test results, links to logs, etc.
         self.job_details = []
         self.artifacts = []  # tuples of name, type, blob
-        self.build_url = ''
         self.build = {
             'product': 'Firefox',
             'release': '',
@@ -748,7 +743,6 @@ class TestJob(object):
             'package': '',
             'revision': '',
             'build_id': '',
-            'build_url': ''
         }
         self.machine = {
             'os_name': '',


### PR DESCRIPTION
See individual commits for clearer diffs/explanations in the commit messages.

Before this merges, the credentials file will need to have top-level "client_id" and "secret" keys added. Once this is in production, the old per-repo credentials can then be removed from the credentials file.
