### PR TITLE
Bug 1248136 - Update to treeherder-client 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 blessings==1.6
 boto==2.38.0
-httplib2==0.9.1
 manifestparser==1.1
-mohawk==0.3.0
 mozdevice==0.46
 mozfile==1.2
 mozinfo==0.8
@@ -10,8 +8,11 @@ mozlog==3.0
 moznetwork==0.27
 mozprocess==0.22
 mozversion==1.3
-oauth2==1.5.211
 requests==2.8.1
-requests-hawk==0.2.1
-treeherder-client==1.8.0
+treeherder-client==2.0.1
 python-dateutil==2.2
+
+# Required by treeherder-client
+mohawk==0.3.1
+requests-hawk==1.0.0
+six==1.10.0


### PR DESCRIPTION
It no longer requires httplib2 and oauth2, however requires requests-hawk>=1.0.0.
